### PR TITLE
Remove erroneous `horisontalAlign`

### DIFF
--- a/src/Page/Grid.elm
+++ b/src/Page/Grid.elm
@@ -222,7 +222,7 @@ variableWidthCode : Html msg
 variableWidthCode =
     Util.toMarkdownElm """
 Grid.container []
-    [ Grid.row [ Row.horisontalAlign Row.centerMd ] -- horizontally center all cols in this row for breakpoint MD (medium) and up.
+    [ Grid.row [ Row.centerMd ] -- horizontally center all cols in this row for breakpoint MD (medium) and up.
         [ Grid.col
             [ Col.xs, Col.lg2 ]
             [ text "1 of 3" ]


### PR DESCRIPTION
`Row.horisontalAlign` doesn't exist (and isn't needed)