### PR TITLE
Added missing type for the parameter of NavbarMsg

### DIFF
--- a/src/Page/Navbar.elm
+++ b/src/Page/Navbar.elm
@@ -122,7 +122,7 @@ initialState toMsg =
 -- Define a message for the navbar
 
 type Msg
-    = NavbarMsg
+    = NavbarMsg Navbar.State
 
 
 -- You need to handle navbar messages in your update function to step the navbar state forward


### PR DESCRIPTION
I couldn't get the example work without adding this extra information.